### PR TITLE
Fixed an issue where a space was sent if the first name and/or last name were missing in the payment data

### DIFF
--- a/includes/class-wc-gateway-payop.php
+++ b/includes/class-wc-gateway-payop.php
@@ -3,7 +3,7 @@
  * WooCommerce Payop Payment Gateway.
  *
  * @extends WC_Payment_Gateway
- * @version 1.0.3
+ * @version 1.0.4
  */
 
 if (!defined('ABSPATH')) {
@@ -157,6 +157,9 @@ class WC_Gateway_Payop extends WC_Payment_Gateway {
 			$data_set[] = $this->secret_key;
 			$signature = hash(PAYOP_HASH_ALGORITHM, implode(':', $data_set));
 
+			$first_name = $order->get_billing_first_name();
+			$last_name = $order->get_billing_last_name();
+
 			$arr_data = [
 				'publicKey' => $this->public_key,
 				'order' => [
@@ -168,7 +171,7 @@ class WC_Gateway_Payop extends WC_Payment_Gateway {
 				],
 				'payer' => [
 					'email' => $order->get_billing_email(),
-					'name' => $order->get_billing_first_name() . ' ' . $order->get_billing_last_name(),
+					'name' => implode(' ', array_filter([$first_name, $last_name])),
 					'phone' => $order->get_billing_phone() ?: ''
 				],
 				'language' => $this->language,

--- a/payop.php
+++ b/payop.php
@@ -4,12 +4,12 @@ Plugin Name: Payop WooCommerce Payment Gateway
 Plugin URI: https://wordpress.org/plugins/payop-woocommerce/
 Description: Payop: Online payment processing service ➦ Accept payments online by 150+ methods from 170+ countries. Payments gateway for Growing Your Business in New Locations and fast online payments
 Author URI: https://payop.com/
-Version: 3.0.7
+Version: 3.0.8
 Requires at least: 6.3
 Tested up to: 6.6
 Requires PHP: 7.4
 WC requires at least: 8.3
-WC tested up to: 9.1.2
+WC tested up to: 9.3.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Domain Path: /languages

--- a/readme.txt
+++ b/readme.txt
@@ -1,12 +1,12 @@
 ﻿=== Payop Official ===
 Tags: credit cards, payment methods, payop, payment gateway
-Version: 3.0.7
-Stable tag: 3.0.7
+Version: 3.0.8
+Stable tag: 3.0.8
 Requires at least: 6.3
 Tested up to: 6.6
 Requires PHP: 7.4
 WC requires at least: 8.3
-WC tested up to: 9.1.2
+WC tested up to: 9.3.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Fixed an issue where a space was sent if the first name and/or last name were missing in the payment data, causing validation errors. Now, if one or both fields are empty, an appropriate string is sent.